### PR TITLE
- error fix for not continuous matrix in OpenCV

### DIFF
--- a/OFIQlib/modules/landmarks/src/adnet_landmarks.cpp
+++ b/OFIQlib/modules/landmarks/src/adnet_landmarks.cpp
@@ -389,7 +389,7 @@ namespace OFIQ_LIB::modules::landmarks
                 detectedFace.height); // (x, y, width, height)
 
             // Crop the image using the ROI
-            cv::Mat croppedImage = cvImage(roi);
+            cv::Mat croppedImage = cvImage(roi).clone();
 
             std::vector<float> landmarks_from_net = landmarkExtractor->extractLandMarks(croppedImage);
             float scalingFactor = detectedFace.height / 256.0f;


### PR DESCRIPTION
In some rare cases, image crops created using ROIs (`cvImage(roi)`) are not continuous matrices, this leads to an exception when this crop is reshaped for processing:
`OpenCV(4.5.5) .../src/modules/core/src/matrix.cpp:1175: error: (-13:Image step is wrong) The matrix is not continuous, thus its number of rows can not be changed in function 'reshape'`
This PR fixes that.