### PR TITLE
Fixed type of Image.data

### DIFF
--- a/OFIQlib/include/ofiq_structs.h
+++ b/OFIQlib/include/ofiq_structs.h
@@ -58,7 +58,7 @@ namespace OFIQ
          * Either RGB color or intensity.
          * If image_depth == 24 this points to  3WH bytes  RGBRGBRGB...
          * If image_depth ==  8 this points to  WH bytes  IIIIIII */
-        std::shared_ptr<uint8_t> data;
+        std::shared_ptr<uint8_t[]> data;
 
         /** 
          * @brief Constructor 
@@ -78,7 +78,7 @@ namespace OFIQ
          * @param depth of the image
          * @param data of the image.
          */
-        Image(uint16_t width, uint16_t height, uint8_t depth, const std::shared_ptr<uint8_t>& data)
+        Image(uint16_t width, uint16_t height, uint8_t depth, const std::shared_ptr<uint8_t[]>& data)
             : width{ width },
             height{ height },
             depth{ depth },

--- a/OFIQlib/modules/utils/src/image_io.cpp
+++ b/OFIQlib/modules/utils/src/image_io.cpp
@@ -54,7 +54,7 @@ namespace OFIQ_LIB
         image.height = static_cast<uint16_t>(cvImage.rows);
         image.depth = 24;
 
-        image.data = std::shared_ptr<uint8_t>(new uint8_t[image.size()], std::default_delete<uint8_t[]>());
+        image.data = std::shared_ptr<uint8_t[]>(new uint8_t[image.size()]);
         memcpy(image.data.get(), cvImage.data, image.size());
 
         return ReturnStatus(retCode, retStatusInfo);

--- a/OFIQlib/modules/utils/src/utils.cpp
+++ b/OFIQlib/modules/utils/src/utils.cpp
@@ -188,7 +188,7 @@ namespace OFIQ_LIB
 
     OFIQ_EXPORT OFIQ::Image MakeGreyImage(uint16_t width, uint16_t height)
     {
-        std::shared_ptr<uint8_t> data{new uint8_t[width * height],std::default_delete<uint8_t[]>()};
+        std::shared_ptr<uint8_t[]> data{new uint8_t[width * height]};
         return {width, height, 8, data};
     }
 


### PR DESCRIPTION
Image.data has type std::shared_ptr<uint8_t>. 
Since it always allocated using new uint8_t[], the type std::shared_ptr<uint8_t[]> shall be used.
This will ensure that always the default deleter is set correctly whitout explicit specification.