### PR TITLE
Added android asset-manager support

### DIFF
--- a/OFIQlib/modules/detectors/src/opencv_ssd_face_detector.cpp
+++ b/OFIQlib/modules/detectors/src/opencv_ssd_face_detector.cpp
@@ -31,6 +31,9 @@
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #include <cmath>
+#include <iterator>
+
+#include "data_source.h"
 
 using namespace OFIQ;
 using namespace cv;
@@ -59,8 +62,13 @@ namespace OFIQ_LIB::modules::detectors
 
         try
         {
+	    data_source protostream(fileNameProtoTxt);
+	    std::vector<unsigned char> prototxt( (std::istreambuf_iterator<char>(protostream)), std::istreambuf_iterator<char>());
+	    data_source caffestream(fileNameCaffeModel);
+	    std::vector<unsigned char> caffemodel((std::istreambuf_iterator<char>(caffestream)), std::istreambuf_iterator<char>());
+
             m_dnnNet =
-                make_shared<dnn::Net>(dnn::readNetFromCaffe(fileNameProtoTxt, fileNameCaffeModel));
+                make_shared<dnn::Net>(dnn::readNetFromCaffe(prototxt, caffemodel));
         }
         catch (const std::exception&)
         {

--- a/OFIQlib/modules/landmarks/src/adnet_landmarks.cpp
+++ b/OFIQlib/modules/landmarks/src/adnet_landmarks.cpp
@@ -27,9 +27,9 @@
 #include "adnet_landmarks.h"
 #include "OFIQError.h"
 #include "utils.h"
+#include "data_source.h"
 
 #include <algorithm>
-#include <fstream>
 #include <onnxruntime_cxx_api.h>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
@@ -244,10 +244,9 @@ namespace OFIQ_LIB::modules::landmarks
             const auto modelPath =
                 config.getDataDir() + "/" + config.GetString("params.landmarks.ADNet.model_path");
 
-            std::ifstream instream(modelPath, std::ios::in | std::ios::binary);
-            std::vector<uint8_t> modelData(
-                (std::istreambuf_iterator<char>(instream)),
-                std::istreambuf_iterator<char>());
+
+            data_source instream(modelPath, std::ios::in | std::ios::binary);
+            std::vector<uint8_t> modelData( (std::istreambuf_iterator<char>(instream)), std::istreambuf_iterator<char>());
 
             landmarkExtractor_->init_session(modelData);
         }

--- a/OFIQlib/modules/measures/src/CompressionArtifacts.cpp
+++ b/OFIQlib/modules/measures/src/CompressionArtifacts.cpp
@@ -29,7 +29,7 @@
 #include "FaceMeasures.h"
 #include "FaceParts.h"
 
-#include <fstream>
+#include "data_source.h"
 
 namespace OFIQ_LIB::modules::measures
 {
@@ -67,7 +67,7 @@ namespace OFIQ_LIB::modules::measures
 
         try
         {
-            std::ifstream instream(modelPath, std::ios::in | std::ios::binary);
+            data_source instream(modelPath, std::ios::in | std::ios::binary);
 
             std::vector<uint8_t> modelData(
                 (std::istreambuf_iterator<char>(instream)),

--- a/OFIQlib/modules/measures/src/ExpressionNeutrality.cpp
+++ b/OFIQlib/modules/measures/src/ExpressionNeutrality.cpp
@@ -27,7 +27,8 @@
 #include "ExpressionNeutrality.h"
 #include "FaceMeasures.h"
 #include "OFIQError.h"
-#include <fstream>
+#include "data_source.h"
+
 #include <opencv2/ml.hpp>
 #include <cmath>
 
@@ -51,7 +52,7 @@ namespace OFIQ_LIB::modules::measures
         
         try
         {
-            std::ifstream instream(modelPathCNN1, std::ios::in | std::ios::binary);
+            data_source instream(modelPathCNN1, std::ios::in | std::ios::binary);
 
             std::vector<uint8_t> modelData(
                 (std::istreambuf_iterator<char>(instream)),
@@ -67,7 +68,7 @@ namespace OFIQ_LIB::modules::measures
 
         try
         {
-            std::ifstream instream(modelPathCNN2, std::ios::in | std::ios::binary);
+            data_source instream(modelPathCNN2, std::ios::in | std::ios::binary);
 
             std::vector<uint8_t> modelData(
                 (std::istreambuf_iterator<char>(instream)),
@@ -83,7 +84,9 @@ namespace OFIQ_LIB::modules::measures
 
         try
         {
-            m_classifier = cv::ml::Boost::load(modelPathAdaboost);
+            data_source instream(modelPathAdaboost);
+            std::string model(std::istreambuf_iterator<char>(instream), {});
+            m_classifier = cv::ml::Boost::loadFromString<cv::ml::Boost>(cv::String(model));
         }
         catch (const std::exception&)
         {

--- a/OFIQlib/modules/measures/src/Sharpness.cpp
+++ b/OFIQlib/modules/measures/src/Sharpness.cpp
@@ -31,6 +31,8 @@
 #include "utils.h"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/opencv.hpp>
+#include <iterator>
+#include "data_source.h"
 
 namespace OFIQ_LIB::modules::measures
 {
@@ -56,7 +58,9 @@ namespace OFIQ_LIB::modules::measures
         {
             try
             {
-                m_rtree = cv::ml::RTrees::load(configuration.getDataDir() + "/" + m_modelFile);
+                data_source modelstream(configuration.getDataDir() + "/" + m_modelFile);
+                std::string model(std::istreambuf_iterator<char>(modelstream), {});
+                m_rtree = cv::ml::RTrees::loadFromString<cv::ml::RTrees>(model);
             }
             catch (const std::exception&)
             {

--- a/OFIQlib/modules/measures/src/UnifiedQualityScore.cpp
+++ b/OFIQlib/modules/measures/src/UnifiedQualityScore.cpp
@@ -29,7 +29,7 @@
 #include "OFIQError.h"
 #include <opencv2/imgproc.hpp>
 #include <opencv2/opencv.hpp>
-#include <fstream>
+#include "data_source.h"
 
 namespace OFIQ_LIB::modules::measures
 {
@@ -57,7 +57,7 @@ namespace OFIQ_LIB::modules::measures
 
             std::string modelPath = configuration.getDataDir()+"/"+configuration.GetString(paramModelpath);
 
-            std::ifstream instream(modelPath, std::ios::in | std::ios::binary);
+            data_source instream(modelPath, std::ios::in | std::ios::binary);
 
             std::vector<uint8_t> modelData(
                 (std::istreambuf_iterator<char>(instream)),

--- a/OFIQlib/modules/poseEstimators/src/HeadPose3DDFAV2.cpp
+++ b/OFIQlib/modules/poseEstimators/src/HeadPose3DDFAV2.cpp
@@ -31,7 +31,7 @@
 #include "FaceMeasures.h"
 #include "AllPoseEstimators.h"
 #include "utils.h"
-#include <fstream>
+#include "data_source.h"
 
 namespace OFIQ_LIB::modules::poseEstimators
 {
@@ -49,7 +49,7 @@ namespace OFIQ_LIB::modules::poseEstimators
             config.getDataDir() + "/" + config.GetString(m_paramPoseEstimatorModel);
         try
         {
-            std::ifstream instream(modelPath, std::ios::in | std::ios::binary);
+            data_source instream(modelPath, std::ios::in | std::ios::binary);
             std::vector<uint8_t> modelData(
                 (std::istreambuf_iterator<char>(instream)),
                 std::istreambuf_iterator<char>());

--- a/OFIQlib/modules/segmentations/src/FaceOcclusionSegmentation.cpp
+++ b/OFIQlib/modules/segmentations/src/FaceOcclusionSegmentation.cpp
@@ -28,7 +28,7 @@
 #include "OFIQError.h"
 #include "utils.h"
 #include <string>
-#include <fstream>
+#include "data_source.h"
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
 
@@ -42,7 +42,7 @@ namespace OFIQ_LIB::modules::segmentations
 
         try
         {
-            std::ifstream instream(modelPath, std::ios::in | std::ios::binary);
+            data_source instream(modelPath, std::ios::in | std::ios::binary);
             std::vector<uint8_t> modelData(
                 (std::istreambuf_iterator<char>(instream)),
                 std::istreambuf_iterator<char>());

--- a/OFIQlib/modules/segmentations/src/FaceParsing.cpp
+++ b/OFIQlib/modules/segmentations/src/FaceParsing.cpp
@@ -28,7 +28,7 @@
 #include "OFIQError.h"
 #include "utils.h"
 #include <string>
-#include <fstream>
+#include "data_source.h"
 #include <opencv2/opencv.hpp>
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
@@ -42,7 +42,7 @@ namespace OFIQ_LIB::modules::segmentations
         
         try
         {
-            std::ifstream instream(modelPath, std::ios::in | std::ios::binary);
+            data_source instream(modelPath, std::ios::in | std::ios::binary);
 
             std::vector<uint8_t> modelData(
                 (std::istreambuf_iterator<char>(instream)),

--- a/OFIQlib/modules/utils/Configuration.h
+++ b/OFIQlib/modules/utils/Configuration.h
@@ -35,6 +35,10 @@
 #include <tao/json/forward.hpp>
 #include <tao/json/value.hpp>
 
+#ifdef ANDROID
+struct AAssetManager;
+#endif
+
  /**
   * Namespace for OFIQ implementations.
   */
@@ -49,6 +53,14 @@ namespace OFIQ_LIB
     class Configuration
     {
     public:
+#ifdef ANDROID
+        /**
+         * @brief Constructor. 
+         * @param assetManager from the android application
+         * @param configFilename Name of the JAXN configuration file in <code>configDir</code>.
+         */
+        Configuration(struct ::AAssetManager* assetManager, const std::string& configDir, const std::string& configFilename);
+#else
         /**
          * @brief Constructor. 
          * @param configDir Directory from which a JAXN configuration is read. The path
@@ -56,7 +68,7 @@ namespace OFIQ_LIB
          * @param configFilename Name of the JAXN configuration file in <code>configDir</code>.
          */
         Configuration(const std::string& configDir, const std::string& configFilename);
-
+#endif
         /**
          * @brief Accesses a boolean configuration.
          * @param key Key of the configuration.

--- a/OFIQlib/modules/utils/data_source.h
+++ b/OFIQlib/modules/utils/data_source.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#ifdef ANDROID
+struct AAsset;
+struct AAssetDir;
+struct AAssetManager;
+
+namespace OFIQ_LIB
+{
+  void SetAAssetManager(::AAssetManager* assetManager);
+
+  class asset_streambuf: public std::streambuf
+  {
+  public:
+    asset_streambuf(::AAsset* asset);
+    virtual ~asset_streambuf() = default;
+  protected:
+    virtual pos_type seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which) override;
+    virtual pos_type seekpos(pos_type pos, std::ios_base::openmode which) override;
+  };
+ 
+  class asset_istream: public std::istream
+  {
+  public:
+    asset_istream(std::string const& filePath, std::ios_base::openmode mode = std::ios_base::in);
+    virtual ~asset_istream();
+  private:
+    ::AAsset* asset;
+    asset_streambuf streambuf;
+  };
+
+  typedef asset_istream data_source;
+}
+
+#else
+
+#include <fstream>
+
+namespace OFIQ_LIB
+{
+  typedef std::ifstream data_source;
+}
+
+#endif
+

--- a/OFIQlib/modules/utils/src/data_source.cpp
+++ b/OFIQlib/modules/utils/src/data_source.cpp
@@ -1,0 +1,84 @@
+#include "data_source.h"
+#include <istream>
+
+#ifdef ANDROID
+#include <android/asset_manager.h>
+#include <android/log.h>
+#include <string>
+
+static AAssetManager* g_assetManager;
+
+namespace OFIQ_LIB
+{
+  using pos_type=std::streambuf::pos_type;
+  using off_type=std::streambuf::off_type;
+
+  void SetAAssetManager(::AAssetManager* assetManager)
+  {
+    g_assetManager = assetManager;
+  }
+
+  asset_streambuf::asset_streambuf(::AAsset* asset)
+  {
+    char* beg(const_cast<char*>(static_cast<char const*>(::AAsset_getBuffer(asset))));
+    char* end(beg + ::AAsset_getLength(asset));
+    __android_log_print(ANDROID_LOG_INFO, __FUNCTION__, "streambuf for asset %p: %p .. %p", asset, beg, end);
+       
+    setg(beg, beg, end);
+  }
+
+  pos_type asset_streambuf::seekoff(off_type off, std::ios_base::seekdir dir, std::ios_base::openmode which)
+  {
+    pos_type result(off_type(-1));
+    if ((which & (std::ios_base::in | std::ios_base::out)) == std::ios_base::in)
+    {
+      switch(dir)
+      {
+        case std::ios::beg:
+          result = off;
+	  break;
+        case std::ios::end:
+	  result = (egptr() - eback()) - (off + 1);
+          break;
+    	case std::ios::cur:
+	  result = (gptr() - eback()) + off;
+	  break;
+        default:
+	  return result;
+      }
+      return(seekpos(result, which)); 
+    }
+    return result; 
+  }
+
+  pos_type asset_streambuf::seekpos(pos_type pos, std::ios_base::openmode which)
+  {
+    if ((which & (std::ios_base::in | std::ios_base::out)) == std::ios_base::in)
+    {
+      char* p(eback() + pos);
+      if((p >= eback()) && (p < egptr()))
+      {
+        setg(eback(), p, egptr());
+        return pos;
+      }
+    }
+    return pos_type(off_type(-1));
+  }
+  
+  asset_istream::asset_istream(std::string const& filePath, std::ios_base::openmode mode)
+   : std::istream(&streambuf)
+   , asset(::AAssetManager_open(g_assetManager, filePath.c_str(), AASSET_MODE_BUFFER))
+   , streambuf(asset)
+  {
+    __android_log_print(ANDROID_LOG_INFO, __FUNCTION__, "opened asset file \"%s\": %p", filePath.c_str(), asset);	
+  }
+
+  asset_istream::~asset_istream()
+  {
+    ::AAsset_close(asset);
+    __android_log_print(ANDROID_LOG_INFO, __FUNCTION__, "closed asset: %p", asset);	
+  }
+}
+
+#endif
+

--- a/OFIQlib/src/OFIQImpl.cpp
+++ b/OFIQlib/src/OFIQImpl.cpp
@@ -42,6 +42,28 @@ using namespace OFIQ_LIB::modules::measures;
 
 OFIQImpl::OFIQImpl():m_emptySession({this->dummyImage, this->dummyAssement}) {}
 
+#ifdef ANDROID
+ReturnStatus OFIQImpl::initialize(::AAssetManager* assetManager, const std::string& configDir, const std::string& configFilename)
+{
+    try
+    {
+        this->config = std::make_unique<Configuration>(assetManager, configDir, configFilename);
+        CreateNetworks();
+        m_executorPtr = CreateExecutor(m_emptySession);
+    }
+    catch (const OFIQError & ex)
+    {
+        return {ex.whatCode(), ex.what()};
+    }
+    catch (const std::exception & ex)
+    {
+        return {ReturnCode::UnknownError, ex.what()};
+    }
+
+    return ReturnStatus(ReturnCode::Success);
+}
+
+#else
 ReturnStatus OFIQImpl::initialize(const std::string& configDir, const std::string& configFilename)
 {
     try
@@ -61,6 +83,7 @@ ReturnStatus OFIQImpl::initialize(const std::string& configDir, const std::strin
 
     return ReturnStatus(ReturnCode::Success);
 }
+#endif
 
 ReturnStatus OFIQImpl::scalarQuality(const OFIQ::Image& face, double& quality)
 {


### PR DESCRIPTION
On Android, the models are provided via the AssetManager. 
A way to load these files within OFIQ without a file system is needed to use these files within OFIQ. 
The proposed change accomplishes this using a special stream class with minimal code changes.