### PR TITLE
Removed unneeded includes to opencv/highgui.cpp

### DIFF
--- a/OFIQlib/modules/measures/src/NaturalColour.cpp
+++ b/OFIQlib/modules/measures/src/NaturalColour.cpp
@@ -30,7 +30,6 @@
 #include "image_utils.h"
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>
 
 namespace OFIQ_LIB::modules::measures
 {

--- a/OFIQlib/modules/utils/src/image_io.cpp
+++ b/OFIQlib/modules/utils/src/image_io.cpp
@@ -31,8 +31,8 @@
 #include <memory>
 #include <fstream>
 #include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
+#include <opencv2/imgcodecs.hpp>
 
 using namespace OFIQ;
 


### PR DESCRIPTION
OpenCV highgui is not available on on platforms.
OFIQLib has two inclusions wich prevents it from being built for those.
Where necessary, and include to imgcodecs replaces the original one.  