### PR TITLE
Update BUILD.md to avoid downloading CMake 4.0.2

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -15,7 +15,7 @@ Install necessary packages.
 </pre>
 To install cmake (in a version 3.26 or higher) use snap (and not apt) as follows.
 <pre>
- $ sudo snap install cmake --classic
+ $ sudo snap refresh cmake --channel=3.26/stable
 </pre>
 Conan is installed via Python with 
 <pre>


### PR DESCRIPTION
Running `sudo snap refresh cmake --classic` resulted in the download of CMake 4.0.2, which broke the compilation (build.sh). Instead, using `sudo snap refresh cmake --channel=3.26/stable` gave a successful compilation.