### PR TITLE
ofiq_config.jaxn duplicate NoHeadCoverings removal and auto-formatting

### DIFF
--- a/data/ofiq_config.jaxn
+++ b/data/ofiq_config.jaxn
@@ -5,8 +5,7 @@
 // license: MIT
 //----------------------------
 {
-
-// python config start
+  // python config start
   "config": {
     "detector": "ssd",
     "landmarks": "ADNet",
@@ -30,7 +29,6 @@
       "UnderExposurePrevention",
       "UnifiedQualityScore",
       "NaturalColour",
-      "NoHeadCoverings",
       "CompressionArtifacts",
       "Luminance",
       "HeadSize"
@@ -52,17 +50,17 @@
       },
       "measures": {
         "BackgroundUniformity": {
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 190,
             "a": 1,
             "s": -1,
             "x0": 10,
-            "w" : 100,
-			"round": true
+            "w": 100,
+            "round": true
           }
         },
         "UnderExposurePrevention": {
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 120,
             "a": 0.832,
             "s": -1,
@@ -75,7 +73,7 @@
           "face_region_alpha": 0.0,
           "use_aligned_landmarks": false,
           "model_path": "models/sharpness/face_sharpness_rtree.xml.gz",
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 1,
             "a": -14.0,
             "s": 115.0,
@@ -85,7 +83,7 @@
           }
         },
         "NaturalColor": {
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 200,
             "a": 1,
             "s": -1,
@@ -95,7 +93,7 @@
           }
         },
         "EyesOpen": {
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 100,
             "x0": 0.02,
             "w": 0.01,
@@ -103,7 +101,7 @@
           }
         },
         "MouthClosed": {
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 100,
             "a": 1,
             "s": -1,
@@ -113,7 +111,7 @@
           }
         },
         "InterEyeDistance": {
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 100,
             "x0": 70.0,
             "w": 20.0,
@@ -121,7 +119,7 @@
           }
         },
         "HeadSize": {
-          "Sigmoid" : {
+          "Sigmoid": {
             // input argument is |raw_score-0.45|, not raw_score
             "h": 200,
             "a": 1,
@@ -131,47 +129,47 @@
             "round": true
           }
         },
-          "LeftwardCropOfTheFaceImage": {
-            "Sigmoid" : {
-              "h": 100,
-              "x0": 0.9,
-              "w": 0.1,
-              "round": true
-            }
-          },
-          "RightwardCropOfTheFaceImage": {
-            "Sigmoid" : {
-              "h": 100,
-              "x0": 0.9,
-              "w": 0.1,
-              "round": true
-            }
-          },
-          "MarginBelowOfTheFaceImage": {
-            "Sigmoid" : {
-              "h": 100,
-              "x0": 1.8,
-              "w": 0.1,
-              "round": true
-            }
-          },
-          "MarginAboveOfTheFaceImage": {
-            "Sigmoid" : {
-              "h": 100,
-              "x0": 1.4,
-              "w": 0.1,
-              "round": true
-            }
-          },
+        "LeftwardCropOfTheFaceImage": {
+          "Sigmoid": {
+            "h": 100,
+            "x0": 0.9,
+            "w": 0.1,
+            "round": true
+          }
+        },
+        "RightwardCropOfTheFaceImage": {
+          "Sigmoid": {
+            "h": 100,
+            "x0": 0.9,
+            "w": 0.1,
+            "round": true
+          }
+        },
+        "MarginBelowOfTheFaceImage": {
+          "Sigmoid": {
+            "h": 100,
+            "x0": 1.8,
+            "w": 0.1,
+            "round": true
+          }
+        },
+        "MarginAboveOfTheFaceImage": {
+          "Sigmoid": {
+            "h": 100,
+            "x0": 1.4,
+            "w": 0.1,
+            "round": true
+          }
+        },
         "NoHeadCoverings": {
-		  // Proportion of pixels classified as head covering <= T0 will lead to a quality component value of 100 (best)
+          // Proportion of pixels classified as head covering <= T0 will lead to a quality component value of 100 (best)
           "T0": 0.0,
-		  // Proportion of pixels classified as head covering >= T1 will lead to a quality component value of 0 (worst)
-		  "T1": 0.95,
-		  // Proportion of pixels classified as head covering in (T0,T1) will be interpolated using a sigmoid function with w as standard deviation 
-		  "w" : 0.1,
-		  // Proportion of pixels classified as head covering in (T0,T1) will be interpolated using a sigmoid function with x0 as development point 
-		  "x0" : 0.02
+          // Proportion of pixels classified as head covering >= T1 will lead to a quality component value of 0 (worst)
+          "T1": 0.95,
+          // Proportion of pixels classified as head covering in (T0,T1) will be interpolated using a sigmoid function with w as standard deviation 
+          "w": 0.1,
+          // Proportion of pixels classified as head covering in (T0,T1) will be interpolated using a sigmoid function with x0 as development point 
+          "x0": 0.02
         },
         "HeadPose": {
           "model_path": "models/head_pose_estimation/mb1_120x120.onnx"
@@ -187,7 +185,7 @@
         },
         "UnifiedQualityScore": {
           "model_path": "models/unified_quality_score/magface_iresnet50_norm.onnx",
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 100,
             "x0": 23.0,
             "w": 2.6,
@@ -198,7 +196,7 @@
           "cnn1_model_path": "models/expression_neutrality/hsemotion/enet_b0_8_best_vgaf_embed_zeroed.onnx",
           "cnn2_model_path": "models/expression_neutrality/hsemotion/enet_b2_8_embed_zeroed.onnx",
           "adaboost_model_path": "models/expression_neutrality/grimmer/hse_1_2_C_adaboost.yml.gz",
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 100,
             "x0": -5000.0,
             "w": 5000.0,
@@ -209,7 +207,7 @@
           "crop": 184,
           "dim": 248,
           "model_path": "models/no_compression_artifacts/ssim_248_model.onnx",
-          "Sigmoid" : {
+          "Sigmoid": {
             "h": 1,
             "a": -0.0278,
             "s": 103.0,


### PR DESCRIPTION
This changes `ofiq_config.jaxn` in two ways:
1. A duplicate `"NoHeadCoverings"` item in `"measures"` is removed.
2. Automatic formatting is applied to the file *(to fix some minor formatting issues)*.