### PR TITLE
set VS compiler version for conan builds to 194

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -30,7 +30,6 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.architecture }}
-        toolset: 14.29
 
     - name: Install Conan
       run: |

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -41,7 +41,7 @@ IF %set_compiler%==16 (
   set "compiler="
 ) else if %set_compiler%==17 (
   set generator="Visual Studio 17 2022"
-  set compiler=-s:a compiler.version=193
+  set compiler=-s:a compiler.version=194
   set vs_version="vc17"
 ) else (
   echo Building on Windows with %set_compiler% is not supported


### PR DESCRIPTION
Updated build.cmd to set VS compiler version for conan builds to 194