### PR TITLE
fix: remove duplicate NoHeadCoverings entry in ofiq_config.jaxn

### DIFF
--- a/data/ofiq_config.jaxn
+++ b/data/ofiq_config.jaxn
@@ -30,7 +30,6 @@
       "UnderExposurePrevention",
       "UnifiedQualityScore",
       "NaturalColour",
-      "NoHeadCoverings",
       "CompressionArtifacts",
       "Luminance",
       "HeadSize"


### PR DESCRIPTION
## Summary
The `NoHeadCoverings` measure was listed **twice** in the `config.measures` array inside `data/ofiq_config.jaxn`.
```json
"measures": [
  ...
  "NoHeadCoverings",   // line 16 — kept
  ...
  "NoHeadCoverings",   // line 33 — duplicate, removed
  ...
]
```
## Impact
- **Runtime**: harmless — OFIQ deduplicates internally and only runs the measure once.
- **Config readability**: misleading, as it implies the measure is applied twice.
- **Tooling**: any tooling that reads the `measures` list (e.g. to present enabled measures to a user) will report `NoHeadCoverings` twice.
## Change
Removed the second (duplicate) occurrence. 1 line deleted, no other changes.